### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:1 AS builder
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+COPY . /opt/sekursranko/
+
+RUN cd /opt/sekursranko \
+&&  cargo build --release --target x86_64-unknown-linux-musl
+
+FROM alpine:3.8
+
+RUN mkdir /sekursranko/ \
+&&  addgroup -S sekursranko \
+&&  adduser -S -G sekursranko sekursranko \
+&&  chown sekursranko:sekursranko /sekursranko/ \
+&&  chmod 0700 /sekursranko/
+
+VOLUME [ "/sekursranko" ]
+
+COPY --from=builder /opt/sekursranko/target/x86_64-unknown-linux-musl/release/sekursranko /usr/local/bin/sekursranko
+COPY --from=builder /opt/sekursranko/config.example.toml /etc/sekursranko/config.toml
+
+RUN sed -i '/listen_on/s/127.0.0.1/[::]/' /etc/sekursranko/config.toml \
+&&  sed -i '/backup_dir/c\backup_dir = "/sekursranko/"' /etc/sekursranko/config.toml
+
+WORKDIR /sekursranko
+
+USER sekursranko
+
+CMD [ "sekursranko", "--config", "/etc/sekursranko/config.toml" ]


### PR DESCRIPTION
Closes dbrgn/sekursranko#6

Example:
```
[timwolla@/t/sekursranko (docker)]docker run -v (pwd)/tank:/sekursranko -it --rm sekursranko:latest                                                                                                         21:25:51
Starting Sekurŝranko server with the following configuration:

- Max backup bytes: 524288
- Retention days: 1460
- Backup directory: "/sekursranko/"
- I/O threads: 4
- Listening address: [::]:3000

[timwolla@/t/sekursranko (docker) [130]]ls -alh tank/                                                                                                                                                       21:28:03
total 12K
drwxrwxrwx 2 root     root     4.0K Dec 16 21:26 ./
drwxrwxr-x 7 timwolla timwolla 4.0K Dec 16 21:25 ../
-rw------- 1      999 docker     10 Dec 16 21:26 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
```

```
[timwolla@~]curl -XPUT -H "Content-Type: application/octet-stream" -H "Accept: application/octet-stream" -H "User-Agent: Threema" -v 172.17.0.2:3000/backups/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef --data-binary Cargo.lock
*   Trying 172.17.0.2...
* Connected to 172.17.0.2 (172.17.0.2) port 3000 (#0)
> PUT /backups/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef HTTP/1.1
> Host: 172.17.0.2:3000
> Content-Type: application/octet-stream
> Accept: application/octet-stream
> User-Agent: Threema
> Content-Length: 10
> 
* upload completely sent off: 10 out of 10 bytes
< HTTP/1.1 201 Created
< content-length: 0
< date: Sun, 16 Dec 2018 20:26:23 GMT
< 
* Connection #0 to host 172.17.0.2 left intact
[timwolla@~]curl -H "Accept: application/octet-stream" -H "User-Agent: Threema" -v 172.17.0.2:3000/backups/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef                                 21:26:23
*   Trying 172.17.0.2...
* Connected to 172.17.0.2 (172.17.0.2) port 3000 (#0)
> GET /backups/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef HTTP/1.1
> Host: 172.17.0.2:3000
> Accept: application/octet-stream
> User-Agent: Threema
> 
< HTTP/1.1 200 OK
< transfer-encoding: chunked
< date: Sun, 16 Dec 2018 20:26:43 GMT
< 
* Connection #0 to host 172.17.0.2 left intact
Cargo.lock⏎                                                                                                                                                                                                         ```